### PR TITLE
Implement Sampler

### DIFF
--- a/source/common/texture/sampler.cpp
+++ b/source/common/texture/sampler.cpp
@@ -3,6 +3,7 @@
 #include "deserialize-utils.hpp"
 
 namespace our {
+    GLuint Sampler::maxTextureUnits = 0;
 
     // Given a json object, this function deserializes the sampler state
     void Sampler::deserialize(const nlohmann::json& data){

--- a/source/common/texture/sampler.hpp
+++ b/source/common/texture/sampler.hpp
@@ -8,39 +8,57 @@ namespace our {
 
     // This class defined an OpenGL sampler
     class Sampler {
-        // The OpenGL object name of this sampler 
+        // The OpenGL object name of this sampler
         GLuint name;
+        static GLuint maxTextureUnits;
+
     public:
         // This constructor creates an OpenGL sampler and saves its object name in the member variable "name" 
         Sampler() {
             //TODO: (Req 6) Complete this function
+            glGenSamplers(1, &name);
+
+            if (maxTextureUnits == 0) {
+                GLint maxUnits;
+                glGetIntegerv(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxUnits);
+                maxTextureUnits = static_cast<GLuint>(maxUnits);
+            }
         };
 
         // This deconstructor deletes the underlying OpenGL sampler
         ~Sampler() { 
             //TODO: (Req 6) Complete this function
+            glDeleteSamplers(1, &name);
          }
 
         // This method binds this sampler to the given texture unit
         void bind(GLuint textureUnit) const {
             //TODO: (Req 6) Complete this function
+            if (textureUnit < maxTextureUnits) {
+                glBindSampler(textureUnit, name);
+            }
         }
 
         // This static method ensures that no sampler is bound to the given texture unit
-        static void unbind(GLuint textureUnit){
+        static void unbind(GLuint textureUnit) {
             //TODO: (Req 6) Complete this function
+            if (textureUnit < maxTextureUnits) {
+                glBindSampler(textureUnit, 0);
+            }
         }
 
         // This function sets a sampler paramter where the value is of type "GLint"
         // This can be used to set the filtering and wrapping parameters
         void set(GLenum parameter, GLint value) const {
             //TODO: (Req 6) Complete this function
+            glSamplerParameteri(name, parameter, value);
         }
 
         // This function sets a sampler paramter where the value is of type "GLfloat"
         // This can be used to set the "GL_TEXTURE_MAX_ANISOTROPY_EXT" parameter
         void set(GLenum parameter, GLfloat value) const {
             //TODO: (Req 6) Complete this function
+            glSamplerParameterf(name, parameter, value);
         }
 
         // This function sets a sampler paramter where the value is of type "GLfloat[4]"

--- a/source/common/texture/texture-utils.cpp
+++ b/source/common/texture/texture-utils.cpp
@@ -28,7 +28,7 @@ our::Texture2D *our::texture_utils::loadImage(const std::string &filename, bool 
     //- 3: RGB
     //- 4: RGB and Alpha (RGBA)
     // Note: channels (the 4th argument) always returns the original number of channels in the file
-    unsigned char *pixels = stbi_load(filename.c_str(), &size.x, &size.y, &channels, 4);
+    unsigned char *pixels = stbi_load(filename.c_str(), &size.x, &size.y, &channels, 0);
     if (pixels == nullptr)
     {
         std::cerr << "Failed to load image: " << filename << std::endl;
@@ -61,7 +61,7 @@ our::Texture2D *our::texture_utils::loadImage(const std::string &filename, bool 
     // Bind the texture to GL_TEXTURE_2D
     texture->bind();
     // Upload the image data to the texture
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.x, size.y, 0, sourceImageFormat, GL_UNSIGNED_BYTE, pixels);
+    glTexImage2D(GL_TEXTURE_2D, 0, sourceImageFormat, size.x, size.y, 0, sourceImageFormat, GL_UNSIGNED_BYTE, pixels);
     // Apply mipmapping if requested
     if (generate_mipmap)
     {


### PR DESCRIPTION
This PR improves how texture samplers and image loading are handled in the project.  

#### **Key Changes:**  
- **Texture Samplers:**  
  - Added a `maxTextureUnits` static member in `Sampler` to track available texture units.  
  - Initialized and deleted OpenGL samplers properly in the constructor/destructor.  

- **Image Loading & Texture Uploading:**  
  - `stbi_load` now preserves the original image channels instead of forcing 4.  
  - `glTexImage2D` now correctly uses the source image format.  