### PR TITLE
feat(collision): add impulse, force, and torque application methods

### DIFF
--- a/config/physics-test/forces-0.jsonc
+++ b/config/physics-test/forces-0.jsonc
@@ -1,0 +1,127 @@
+{
+    "start-scene": "physics-test",
+    "window":
+    {
+        "title":"Physics Test Window",
+        "size":{
+            "width":512,
+            "height":512
+        },
+        "fullscreen": false
+    },
+    "screenshots":{
+        "directory": "screenshots/physics-test",
+        "requests": [
+            { "file": "mesh-0.png", "frame":  1 }
+        ]
+    },
+    "scene": {
+        "renderer": {
+            "hdr": {
+            "enable": false,
+            "hdr_texture": "barcelona_rooftop",
+            "maxMipLevels": 5
+            }
+        },
+        "assets": {
+            "meshes": {
+                "sphere": "assets/models/sphere/sphere.gltf"
+            }
+        },
+        "world": [
+            {
+                "position": [0, 0, 10],
+                "components": [
+                    {
+                    "type": "Camera",
+                    "fovY": 60.0
+                    },
+                    {
+                    "type": "Free Camera Controller",
+                    "speedupFactors": 1.5,
+                    "positionSensitivity": [2.0, 2.0, 2.0],
+                    "rotationSensitivity": 0.001
+                    }
+                ]
+            },
+            {
+                "position": [0, -5, -1],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [4, 0.5, 4]
+                    }
+                ]
+            },
+            {
+                "position": [0, 3, -1],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [4, 0.5, 4]
+                    }
+                ]
+            },
+            {
+                "position": [0, -2, -5],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [6, 6, 0.5]
+                    }
+                ]
+            },
+            {
+                "position": [0, -2, 3],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [6, 6, 0.5]
+                    }
+                ]
+            },
+            {
+                "position": [5, -2, -1],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [0.5, 6, 6]
+                    }
+                ]
+            },
+            {
+                "position": [-5, -2, -1],
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "box",
+                        "mass": 0,
+                        "halfExtents": [0.5, 6, 6]
+                    }
+                ]
+            },
+            {
+                "position": [0, -2, -1],
+                "name": "Ball",
+                "components": [
+                    {
+                        "type": "Collision",
+                        "shape": "mesh",
+                        "mass": 1,
+                        "mesh": "sphere"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/source/common/systems/collision-system.cpp
+++ b/source/common/systems/collision-system.cpp
@@ -253,6 +253,37 @@ namespace our {
         return false;
     }
 
+    void CollisionSystem::applyImpulse(Entity* entity, const glm::vec3& force, const glm::vec3& position) {
+        if (auto collision = entity->getComponent<CollisionComponent>()) {
+            if (collision->bulletBody && collision->mass > 0.0f) {
+                btVector3 btForce(force.x, force.y, force.z);
+                btVector3 btPosition(position.x, position.y, position.z);
+                collision->bulletBody->applyImpulse(btForce, btPosition);
+                collision->bulletBody->activate();
+            }
+        }
+    }
+    
+    void CollisionSystem::applyForce(Entity* entity, const glm::vec3& force, const glm::vec3& position) {
+        if (auto collision = entity->getComponent<CollisionComponent>()) {
+            if (collision->bulletBody && collision->mass > 0.0f) {
+                btVector3 btForce(force.x, force.y, force.z);
+                btVector3 btPosition(position.x, position.y, position.z);
+                collision->bulletBody->applyForce(btForce, btPosition);
+                collision->bulletBody->activate();
+            }
+        }
+    }
+    
+    void CollisionSystem::applyTorque(Entity* entity, const glm::vec3& torque) {
+        if (auto collision = entity->getComponent<CollisionComponent>()) {
+            if (collision->bulletBody && collision->mass > 0.0f) {
+                collision->bulletBody->applyTorque(btVector3(torque.x, torque.y, torque.z));
+                collision->bulletBody->activate();
+            }
+        }
+    }
+
     void CollisionSystem::debugDrawRay(const glm::vec3& start, const glm::vec3& end, const glm::vec3& color) {
         if (debugDrawer) {
             debugDrawer->drawLine(

--- a/source/common/systems/collision-system.hpp
+++ b/source/common/systems/collision-system.hpp
@@ -126,7 +126,6 @@ public:
     // Initialize the collision system with a Bullet physics world
     void initialize(glm::ivec2 windowSize, btDynamicsWorld* physicsWorld);
 
-
     // Get the Bullet physics world
     btDiscreteDynamicsWorld* getPhysicsWorld() { return physicsWorld; }
 
@@ -136,6 +135,15 @@ public:
     // Perform a raycast and return hit results
     bool raycast(const glm::vec3& start, const glm::vec3& end, 
         CollisionComponent*& hitComponent, glm::vec3& hitPoint, glm::vec3& hitNormal);
+
+    // Apply an instant impulse (e.g., for throwing)
+    void applyImpulse(Entity* entity, const glm::vec3& force, const glm::vec3& position = glm::vec3(0));
+    
+    // Apply continuous force (e.g., wind, thrusters)
+    void applyForce(Entity* entity, const glm::vec3& force, const glm::vec3& position = glm::vec3(0));
+    
+    // Apply torque for rotation (e.g., spinning objects)
+    void applyTorque(Entity* entity, const glm::vec3& torque);
 
     // Debug draw the world using the debug drawer
     void debugDrawWorld(World* world);

--- a/source/states/physics-test-state.hpp
+++ b/source/states/physics-test-state.hpp
@@ -113,6 +113,45 @@ class PhysicsTestState : public our::State {
     }
 
     void onDraw(double deltaTime) override {
+        auto keyboard = getApp()->getKeyboard();
+        our::Entity* ballEntity = nullptr;
+        our::Entity* camera = nullptr;
+        for (auto entity : world.getEntities()) {
+            if (entity->getComponent<our::CameraComponent>()) {
+                camera = entity;
+            }
+            if (entity->name == "Ball") {
+                ballEntity = entity;
+            }
+        }
+        if (keyboard.isPressed(GLFW_KEY_F)) {
+            if (ballEntity) {
+                // Get player's forward direction from their transform
+                our::Entity* player = camera;
+                glm::vec3 throwDirection = camera->localTransform.rotation * glm::vec3(0, 0, -1); // Forward direction
+                throwDirection = glm::normalize(throwDirection); // Normalize the direction
+                
+                // Apply impulse (direction * strength)
+                collisionSystem.applyImpulse(ballEntity, glm::vec3(0, 1, 0));
+            }
+        } else if (keyboard.isPressed(GLFW_KEY_R)) {
+            if (ballEntity) {
+                // Reset the ball's position and velocity
+                collisionSystem.applyTorque(ballEntity, glm::vec3(0, 10.0f, 0));
+            }
+        } else if (keyboard.isPressed(GLFW_KEY_T)) {
+            if (ballEntity) {
+                glm::vec3 handPosition = camera->localTransform.position + glm::vec3(0, 1.0f, 0);
+                // Make a random throw direction
+                glm::vec3 throwDirection = glm::vec3(
+                    0.0f, 1.0f, 0.0f // Upward direction
+                );
+                glm::vec3 torque = glm::normalize(glm::vec3(1.0f, 1.0f, 0.0f)) * 10.0f;
+                collisionSystem.applyTorque(ballEntity, torque);
+                collisionSystem.applyImpulse(ballEntity, throwDirection, handPosition);
+            }
+        }
+
         cameraController.update(&world, (float)deltaTime);
         collisionSystem.update(&world, (float)deltaTime);
         raycast();


### PR DESCRIPTION
This pull request introduces a new physics test scene configuration, enhances the collision system with new methods for applying forces, and integrates these features into the `PhysicsTestState` for interactive functionality. The changes aim to improve the physics simulation and provide user-controlled interactions.

### Physics Test Scene Configuration:
* Added a new JSON configuration file, `config/physics-test/forces-0.jsonc`, defining a physics test scene with a camera, static collision boxes, and a dynamic ball entity. This configuration includes rendering settings, assets, and world components.

### Collision System Enhancements:
* Introduced three new methods in the `CollisionSystem` class:
  - [`applyImpulse`](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286): Applies an instant impulse to an entity (e.g., for throwing). [[1]](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286) [[2]](diffhunk://#diff-a2ca14b920c0211f4fd5330996426bfac4722a8a0b4fc673da8bf3373c328856R139-R147)
  - [`applyForce`](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286): Applies a continuous force to an entity (e.g., for wind or thrusters). [[1]](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286) [[2]](diffhunk://#diff-a2ca14b920c0211f4fd5330996426bfac4722a8a0b4fc673da8bf3373c328856R139-R147)
  - [`applyTorque`](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286): Applies torque to an entity for rotational motion. [[1]](diffhunk://#diff-39373fde35957432def90c03d969bd65e8ea2e49d4910df88972ee36bd47de7cR256-R286) [[2]](diffhunk://#diff-a2ca14b920c0211f4fd5330996426bfac4722a8a0b4fc673da8bf3373c328856R139-R147)

### Interactive Physics Features:
* Updated the `PhysicsTestState` to allow user interaction with the physics system:
  - Pressing `F` applies an upward impulse to the ball.
  - Pressing `R` applies torque to spin the ball.
  - Pressing `T` applies both torque and an upward impulse with a hand-position offset.